### PR TITLE
fix: decorate sensor/entity handlers with @callback

### DIFF
--- a/custom_components/hailo_ollama/ai_task.py
+++ b/custom_components/hailo_ollama/ai_task.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from typing import Any
 
 from homeassistant.components import conversation
@@ -13,10 +14,10 @@ from homeassistant.components.ai_task import (
     GenDataTaskResult,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.dispatcher import async_dispatcher_connect, async_dispatcher_send
 
 from .const import (
     CONF_HOST,
@@ -30,6 +31,7 @@ from .const import (
     DEFAULT_SYSTEM_PROMPT,
     DOMAIN,
     SIGNAL_AVAILABILITY_CHANGED,
+    SIGNAL_METRICS_UPDATED,
 )
 from .conversation import HailoError, HailoOllamaClientMixin, _process_thinking
 
@@ -81,6 +83,7 @@ class HailoAITaskEntity(AITaskEntity, HailoOllamaClientMixin):
             )
         )
 
+    @callback
     def _handle_availability(self, available: bool) -> None:
         self.async_write_ha_state()
 
@@ -114,6 +117,7 @@ class HailoAITaskEntity(AITaskEntity, HailoOllamaClientMixin):
             {"role": "user", "content": task.instructions},
         ]
 
+        t0 = time.monotonic()
         try:
             if self._streaming:
                 response_text = await self._call_streaming(messages)
@@ -123,7 +127,13 @@ class HailoAITaskEntity(AITaskEntity, HailoOllamaClientMixin):
             _LOGGER.error("Hailo AI task error: %s", err)
             raise
 
+        elapsed = time.monotonic() - t0
         clean_text = _process_thinking(response_text, self._show_thinking)
+        async_dispatcher_send(
+            self.hass,
+            SIGNAL_METRICS_UPDATED.format(self._entry.entry_id),
+            {"response_time": round(elapsed, 2), "response_chars": len(clean_text)},
+        )
         return GenDataTaskResult(
             conversation_id=chat_log.conversation_id,
             data=clean_text,

--- a/custom_components/hailo_ollama/conversation.py
+++ b/custom_components/hailo_ollama/conversation.py
@@ -13,7 +13,7 @@ import aiohttp
 
 from homeassistant.components import conversation
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import intent
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import async_dispatcher_connect, async_dispatcher_send
@@ -277,6 +277,7 @@ class HailoOllamaConversationEntity(
             )
         )
 
+    @callback
     def _handle_availability(self, available: bool) -> None:
         self.async_write_ha_state()
 

--- a/custom_components/hailo_ollama/sensor.py
+++ b/custom_components/hailo_ollama/sensor.py
@@ -9,7 +9,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTime
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -60,6 +60,7 @@ class _HailoMetricSensor(SensorEntity):
             )
         )
 
+    @callback
     def _handle_availability(self, available: bool) -> None:
         self.async_write_ha_state()
 
@@ -72,6 +73,7 @@ class _HailoMetricSensor(SensorEntity):
             .get("available", True)
         )
 
+    @callback
     def _handle_metrics(self, metrics: dict) -> None:
         """Update state from metrics dict and push to HA."""
         self._update_from_metrics(metrics)

--- a/tests/test_ai_task.py
+++ b/tests/test_ai_task.py
@@ -332,3 +332,46 @@ def test_available_true_when_domain_data_says_available(mock_config_entry):
     hass.data = {DOMAIN: {mock_config_entry.entry_id: {"available": True}}}
     entity.hass = hass
     assert entity.available is True
+
+
+# ---------------------------------------------------------------------------
+# Metrics dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_data_dispatches_metrics():
+    """_async_generate_data dispatches SIGNAL_METRICS_UPDATED with response_time and response_chars."""
+    from custom_components.hailo_ollama.const import SIGNAL_METRICS_UPDATED
+
+    entity = _make_entity({
+        CONF_HOST: "localhost",
+        CONF_PORT: 8000,
+        CONF_MODEL: "llama3.2:3b",
+        CONF_SYSTEM_PROMPT: DEFAULT_SYSTEM_PROMPT,
+        CONF_STREAMING: False,
+    })
+    entity._call_non_streaming = AsyncMock(return_value="Sensor response.")
+
+    task = MagicMock()
+    task.instructions = "Generate data."
+
+    with patch(
+        "custom_components.hailo_ollama.ai_task.async_dispatcher_send"
+    ) as mock_send:
+        await entity._async_generate_data(task, _make_chat_log())
+
+    mock_send.assert_called_once()
+    signal = mock_send.call_args.args[1]
+    metrics = mock_send.call_args.args[2]
+    assert signal == SIGNAL_METRICS_UPDATED.format(entity._entry.entry_id)
+    assert "response_time" in metrics
+    assert metrics["response_chars"] == len("Sensor response.")
+
+
+def test_handle_availability_is_callback(mock_config_entry):
+    """_handle_availability must be decorated with @callback so HA calls it on the event loop."""
+    from homeassistant.core import is_callback
+
+    entity = HailoAITaskEntity(mock_config_entry)
+    assert is_callback(entity._handle_availability)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -167,3 +167,19 @@ def test_handle_metrics_updates_state_and_writes(mock_config_entry):
 
     assert sensor._attr_native_value == 3.0
     sensor.async_write_ha_state.assert_called_once()
+
+
+def test_handle_metrics_is_callback(mock_config_entry):
+    """_handle_metrics must be decorated with @callback so HA calls it on the event loop."""
+    from homeassistant.core import is_callback
+
+    sensor = HailoResponseTimeSensor(mock_config_entry)
+    assert is_callback(sensor._handle_metrics)
+
+
+def test_handle_availability_is_callback(mock_config_entry):
+    """_handle_availability must be decorated with @callback so HA calls it on the event loop."""
+    from homeassistant.core import is_callback
+
+    sensor = HailoResponseTimeSensor(mock_config_entry)
+    assert is_callback(sensor._handle_availability)


### PR DESCRIPTION
and dispatch metrics from ai_task

Without @callback, HA's dispatcher classified _handle_metrics and _handle_availability as HassJobType.Executor and ran them in a thread pool. Calling async_write_ha_state() from a thread violates HA's event-loop safety contract, silently preventing sensor state updates.

Also adds response_time and response_chars metric dispatch to HailoAITaskEntity so sensors update on AI task responses as well.